### PR TITLE
new Standalone option (#70)

### DIFF
--- a/cmd/manager/exec/options.go
+++ b/cmd/manager/exec/options.go
@@ -18,18 +18,20 @@ import (
 	pflag "github.com/spf13/pflag"
 )
 
-// PlacementRuleCMDOptions for command line flag parsing
-type PlacementRuleCMDOptions struct {
+// SubscriptionCMDOptions for command line flag parsing
+type SubscriptionCMDOptions struct {
 	MetricsAddr           string
 	ClusterName           string
 	ClusterNamespace      string
 	HubConfigFilePathName string
 	SyncInterval          int
+	Standalone            bool
 }
 
-var Options = PlacementRuleCMDOptions{
+var Options = SubscriptionCMDOptions{
 	MetricsAddr:  "",
 	SyncInterval: 60,
+	Standalone:   false,
 }
 
 // ProcessFlags parses command line parameters into Options
@@ -69,5 +71,12 @@ func ProcessFlags() {
 		"sync-interval",
 		Options.SyncInterval,
 		"The interval of housekeeping in seconds.",
+	)
+
+	flag.BoolVar(
+		&Options.Standalone,
+		"standalone",
+		Options.Standalone,
+		"Standalone mode.",
 	)
 }

--- a/pkg/controller/add_mcm_hub.go
+++ b/pkg/controller/add_mcm_hub.go
@@ -18,5 +18,5 @@ import "github.com/IBM/multicloud-operators-subscription/pkg/controller/mcmhub"
 
 func init() {
 	// AddToManagerFuncs is a list of functions to create controllers and add them to a manager.
-	AddToManagerFuncs = append(AddToManagerFuncs, mcmhub.Add)
+	AddHubToManagerFuncs = append(AddHubToManagerFuncs, mcmhub.Add)
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -25,6 +25,9 @@ var AddToManagerMCMFuncs []func(manager.Manager, *rest.Config) error
 // AddToManagerFuncs is a list of functions to add all Controllers to the Manager
 var AddToManagerFuncs []func(manager.Manager) error
 
+// AddHubToManagerFuncs is a list of functions to add all Hub Controllers to the Manager
+var AddHubToManagerFuncs []func(manager.Manager) error
+
 // AddToManager adds all Controllers to the Manager
 func AddToManager(m manager.Manager, cfg *rest.Config) error {
 	for _, f := range AddToManagerFuncs {
@@ -35,6 +38,17 @@ func AddToManager(m manager.Manager, cfg *rest.Config) error {
 
 	for _, f := range AddToManagerMCMFuncs {
 		if err := f(m, cfg); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// AddHubToManager adds all Hub Controllers to the Manager
+func AddHubToManager(m manager.Manager) error {
+	for _, f := range AddHubToManagerFuncs {
+		if err := f(m); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
* Annotation RollingUpdateMaxUnavailable need to be copied to subscription deploayble

* new standalone option

Signed-off-by: Xiangjing Li <xilica.ibm.com@xiangjings-mbp.war.can.ibm.com>

* only hub controller is started when the standalone mode is disabled

Signed-off-by: Xiangjing Li <xilica.ibm.com@xiangjings-mbp.war.can.ibm.com>

* only hub could be leader

Signed-off-by: Xiangjing Li <xilica.ibm.com@xiangjings-mbp.war.can.ibm.com>