### PR TITLE
Support both polling repos for changes and webhook events (#85)

### DIFF
--- a/cmd/manager/exec/manager.go
+++ b/cmd/manager/exec/manager.go
@@ -122,6 +122,12 @@ func RunManager(sig <-chan struct{}) {
 			klog.Error(err, "")
 			os.Exit(1)
 		}
+
+		// Setup Webhook listner
+		if err := webhook.AddToManager(mgr, hubconfig, Options.TLSKeyFilePathName, Options.TLSCrtFilePathName); err != nil {
+			klog.Error("Failed to initialize WebHook listener with error:", err)
+			os.Exit(1)
+		}
 	} else if err := setupStandalone(mgr, hubconfig, id); err != nil {
 		klog.Error("Failed to setup standalone subscription, error:", err)
 		os.Exit(1)
@@ -184,13 +190,13 @@ func setupStandalone(mgr manager.Manager, hubconfig *rest.Config, id *types.Name
 
 	// Setup Subscribers
 	if err := subscriber.AddToManager(mgr, hubconfig, id, Options.SyncInterval); err != nil {
-		klog.Error("Failed to initialize synchronizer with error:", err)
+		klog.Error("Failed to initialize subscriber with error:", err)
 		return err
 	}
 
 	// Setup all Controllers
 	if err := controller.AddToManager(mgr, hubconfig); err != nil {
-		klog.Error(err, "")
+		klog.Error("Failed to initialize controller with error:", err)
 		return err
 	}
 

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -18,6 +18,8 @@ spec:
       containers:
         - name: multicloud-operators-subscription
           image: quay.io/multicloudlab/multicloud-operators-subscription
+          ports:
+          - containerPort: 8443
           command:
           - /usr/local/bin/multicloud-operators-subscription
           - --standalone

--- a/deploy/service.yaml
+++ b/deploy/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: multicloud-operators-subscription
+  name: multicloud-operators-subscription
+spec:
+  ports:
+  - port: 8443
+    protocol: TCP
+    targetPort: 8443
+  selector:
+    name: multicloud-operators-subscription
+  sessionAffinity: None
+  type: ClusterIP

--- a/deploy/standalone/operator.yaml
+++ b/deploy/standalone/operator.yaml
@@ -18,6 +18,8 @@ spec:
       containers:
         - name: multicloud-operators-subscription
           image: quay.io/multicloudlab/multicloud-operators-subscription
+          ports:
+          - containerPort: 8443
           command:
           - /usr/local/bin/multicloud-operators-subscription
           - --sync-interval=10

--- a/deploy/standalone/service.yaml
+++ b/deploy/standalone/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: multicloud-operators-subscription
+  name: multicloud-operators-subscription
+spec:
+  ports:
+  - port: 8443
+    protocol: TCP
+    targetPort: 8443
+  selector:
+    name: multicloud-operators-subscription
+  sessionAffinity: None
+  type: ClusterIP

--- a/pkg/subscriber/github/subscriber_item.go
+++ b/pkg/subscriber/github/subscriber_item.go
@@ -83,7 +83,7 @@ type kubeResource struct {
 	Kind       string `yaml:"kind"`
 }
 
-// Start subscribes a subscriber item with namespace channel
+// Start subscribes a subscriber item with github channel
 func (ghsi *SubscriberItem) Start() {
 	// do nothing if already started
 	if ghsi.stopch != nil {
@@ -92,6 +92,8 @@ func (ghsi *SubscriberItem) Start() {
 	}
 
 	ghsi.stopch = make(chan struct{})
+
+	klog.Info("Polling on SubscriberItem ", ghsi.Subscription.Name)
 
 	go wait.Until(func() {
 		tw := ghsi.SubscriberItem.Subscription.Spec.TimeWindow
@@ -119,6 +121,7 @@ func (ghsi *SubscriberItem) Stop() {
 }
 
 func (ghsi *SubscriberItem) doSubscription() error {
+	klog.V(2).Info("Subscribing ...", ghsi.Subscription.Name)
 	//Clone the git repo
 	commitID, err := ghsi.cloneGitRepo()
 	if err != nil {
@@ -127,7 +130,7 @@ func (ghsi *SubscriberItem) doSubscription() error {
 	}
 
 	if commitID != ghsi.commitID {
-		klog.V(4).Info("The commit ID is different. Process the cloned repo")
+		klog.V(2).Info("The commit ID is different. Process the cloned repo")
 
 		err := ghsi.sortClonedGitRepo()
 		if err != nil {
@@ -171,7 +174,7 @@ func (ghsi *SubscriberItem) doSubscription() error {
 		ghsi.otherFiles = nil
 		ghsi.indexFile = nil
 	} else {
-		klog.V(4).Info("The commit ID is same as before. Skip processing the cloned repo")
+		klog.V(2).Info("The commit ID is same as before. Skip processing the cloned repo")
 	}
 
 	return nil

--- a/pkg/webhook/listener/github_events.go
+++ b/pkg/webhook/listener/github_events.go
@@ -49,6 +49,8 @@ func (listener *WebhookListener) handleGithubWebhook(r *http.Request) error {
 
 	var err error
 
+	eventType := github.WebHookType(r)
+
 	body, signature, event, err = listener.ParseRequest(r)
 	if err != nil {
 		klog.Error("Failed to parse the request. error:", err)
@@ -64,77 +66,102 @@ func (listener *WebhookListener) handleGithubWebhook(r *http.Request) error {
 		return err
 	}
 
-	// Loop through all subscriptions
-	for _, sub := range subList.Items {
-		klog.V(2).Info("Evaluating subscription: " + sub.GetName())
-
-		chNamespace := ""
-		chName := ""
-		chType := ""
-
-		if sub.Spec.Channel != "" {
-			strs := strings.Split(sub.Spec.Channel, "/")
-			if len(strs) == 2 {
-				chNamespace = strs[0]
-				chName = strs[1]
-			} else {
-				klog.Info("Failed to get channel namespace and name.")
+	if strings.EqualFold(eventType, "push") || strings.EqualFold(eventType, "pull") {
+		// Loop through all subscriptions
+		for _, sub := range subList.Items {
+			if !listener.processSubscription(sub, event, signature, eventType, body) {
 				continue
 			}
 		}
-
-		chkey := types.NamespacedName{Name: chName, Namespace: chNamespace}
-		chobj := &chnv1alpha1.Channel{}
-		err := listener.RemoteClient.Get(context.TODO(), chkey, chobj)
-
-		if err == nil {
-			chType = string(chobj.Spec.Type)
-		} else {
-			klog.Error("Failed to get subscription's channel. error: ", err)
-			continue
-		}
-
-		// This WebHook event is applicable for this subscription if:
-		// 		1. channel type is github
-		// 		2. AND ValidateSignature is true with the channel's secret token
-		// 		3. AND channel path contains the repo full name from the event
-		// If these conditions are not met, skip to the next subscription.
-
-		if !strings.EqualFold(chType, chnv1alpha1.ChannelTypeGitHub) {
-			klog.V(2).Infof("The channel type is %s. Skipping to process this subscription.", chType)
-			continue
-		}
-
-		if signature != "" {
-			if !listener.validateSecret(signature, chobj.GetAnnotations(), chNamespace, body) {
-				continue
-			}
-		}
-
-		switch e := event.(type) {
-		case *github.PullRequestEvent:
-			if chobj.Spec.PathName == e.GetRepo().GetCloneURL() ||
-				chobj.Spec.PathName == e.GetRepo().GetHTMLURL() ||
-				chobj.Spec.PathName == e.GetRepo().GetURL() ||
-				strings.Contains(chobj.Spec.PathName, e.GetRepo().GetFullName()) {
-				klog.Info("Processing PUSH event from " + e.GetRepo().GetHTMLURL())
-				listener.updateSubscription(sub)
-			}
-		case *github.PushEvent:
-			if chobj.Spec.PathName == e.GetRepo().GetCloneURL() ||
-				chobj.Spec.PathName == e.GetRepo().GetHTMLURL() ||
-				chobj.Spec.PathName == e.GetRepo().GetURL() ||
-				strings.Contains(chobj.Spec.PathName, e.GetRepo().GetFullName()) {
-				klog.Info("Processing PUSH event from " + e.GetRepo().GetHTMLURL())
-				listener.updateSubscription(sub)
-			}
-		default:
-			klog.Infof("Unhandled event type %s\n", github.WebHookType(r))
-			continue
-		}
+	} else {
+		klog.V(2).Infof("Unhandled webhook event type %s\n", eventType)
 	}
 
 	return nil
+}
+
+func (listener *WebhookListener) processSubscription(sub appv1alpha1.Subscription, event interface{}, signature, eventType string, body []byte) bool {
+	klog.V(2).Info("Evaluating subscription: " + sub.GetName())
+
+	chNamespace := ""
+	chName := ""
+
+	if sub.Spec.Channel != "" {
+		strs := strings.Split(sub.Spec.Channel, "/")
+		if len(strs) == 2 {
+			chNamespace = strs[0]
+			chName = strs[1]
+		} else {
+			klog.Error("Failed to get channel namespace and name.")
+			return false
+		}
+	}
+
+	chkey := types.NamespacedName{Name: chName, Namespace: chNamespace}
+	chobj := &chnv1alpha1.Channel{}
+	err := listener.RemoteClient.Get(context.TODO(), chkey, chobj)
+
+	if err != nil {
+		klog.Error("Failed to get subscription's channel. error: ", err)
+		return false
+	}
+
+	if !listener.validateChannel(chobj, signature, chNamespace, body) {
+		return false
+	}
+
+	switch e := event.(type) {
+	case *github.PullRequestEvent:
+		if chobj.Spec.PathName == e.GetRepo().GetCloneURL() ||
+			chobj.Spec.PathName == e.GetRepo().GetHTMLURL() ||
+			chobj.Spec.PathName == e.GetRepo().GetURL() ||
+			strings.Contains(chobj.Spec.PathName, e.GetRepo().GetFullName()) {
+			klog.V(2).Info("Processing PUSH event from " + e.GetRepo().GetHTMLURL())
+			listener.updateSubscription(sub)
+		}
+	case *github.PushEvent:
+		if chobj.Spec.PathName == e.GetRepo().GetCloneURL() ||
+			chobj.Spec.PathName == e.GetRepo().GetHTMLURL() ||
+			chobj.Spec.PathName == e.GetRepo().GetURL() ||
+			strings.Contains(chobj.Spec.PathName, e.GetRepo().GetFullName()) {
+			klog.V(2).Info("Processing PUSH event from " + e.GetRepo().GetHTMLURL())
+			listener.updateSubscription(sub)
+		}
+	default:
+		klog.Infof("Unhandled webhook event type %s\n", eventType)
+		return false
+	}
+
+	return true
+}
+
+func (listener *WebhookListener) validateChannel(chobj *chnv1alpha1.Channel, signature, chNamespace string, body []byte) bool {
+	// This WebHook event is applicable for this subscription if:
+	// 		1. channel type is github
+	// 		2. AND ValidateSignature is true with the channel's secret token
+	// 		3. AND channel path contains the repo full name from the event
+	//      4. AND channel has annotation webhookenabled="true"
+	// If these conditions are not met, skip to the next subscription.
+	chType := string(chobj.Spec.Type)
+
+	if !strings.EqualFold(chType, chnv1alpha1.ChannelTypeGitHub) {
+		klog.V(2).Infof("The channel type is %s. Skipping to process this subscription.", chType)
+		return false
+	}
+
+	if !strings.EqualFold(chobj.GetAnnotations()["webhookenabled"], "true") {
+		klog.V(2).Infof("WebHook event listening is not enabled on the channel. Skipping to process this subscription.")
+		return false
+	}
+
+	if signature != "" {
+		if !listener.validateSecret(signature, chobj.GetAnnotations(), chNamespace, body) {
+			klog.V(2).Infof("WebHook secret validation failed. Skipping to process this subscription.")
+			return false
+		}
+	}
+
+	return true
 }
 
 // ParseRequest parses incoming WebHook event request


### PR DESCRIPTION
* More update on github subscription

Ability to either poll github repo or reconcile on webhook events.

* go lint

* Service for port 8443